### PR TITLE
Update CAPI version to v1.1.0-gsalpha.2 from our fork

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ workflows:
       - architect/push-to-app-catalog:
           context: "architect"
           # executor: "app-build-suite" # uncomment this if you want automatic metadata generation
-          name: "package and push cluster-api chart"
+          name: push-cluster-api-to-control-plane-catalog
           app_catalog: "control-plane-catalog"
           app_catalog_test: "control-plane-test-catalog"
           chart: "cluster-api"

--- a/helm/cluster-api/Chart.yaml
+++ b/helm/cluster-api/Chart.yaml
@@ -12,4 +12,4 @@ annotations:
     - catalog: default
       provider: azure
       team: celestial
-  config.giantswarm.io/version: 1.x.x
+  config.giantswarm.io/version: update-cluster-api-app

--- a/helm/cluster-api/Chart.yaml
+++ b/helm/cluster-api/Chart.yaml
@@ -12,4 +12,4 @@ annotations:
     - catalog: default
       provider: azure
       team: celestial
-  config.giantswarm.io/version: update-cluster-api-app
+  config.giantswarm.io/version: 1.x.x

--- a/helm/cluster-api/templates/bootstrap/webhook.yaml
+++ b/helm/cluster-api/templates/bootstrap/webhook.yaml
@@ -12,7 +12,7 @@ webhooks:
     service:
       name: {{ include "resource.bootstrap.name" . }}
       namespace: {{ include "resource.default.namespace" . }}
-      path: /validate-bootstrap-cluster-x-k8s-io-v1alpha4-kubeadmconfig
+      path: /validate-bootstrap-cluster-x-k8s-io-v1beta1-kubeadmconfig
       port: {{ .Values.ports.webhook }}
   failurePolicy: Fail
   matchPolicy: Equivalent
@@ -24,7 +24,7 @@ webhooks:
   - apiGroups:
     - bootstrap.cluster.x-k8s.io
     apiVersions:
-    - v1alpha4
+    - v1beta1
     operations:
     - CREATE
     - UPDATE

--- a/helm/cluster-api/templates/controlplane/webhook.yaml
+++ b/helm/cluster-api/templates/controlplane/webhook.yaml
@@ -39,6 +39,7 @@ webhooks:
       path: /mutate-controlplane-cluster-x-k8s-io-v1beta1-kubeadmcontrolplanetemplate
       port: {{ .Values.ports.webhook }}
   failurePolicy: Fail
+  matchPolicy: Equivalent
   name: default.kubeadmcontrolplanetemplate.controlplane.cluster.x-k8s.io
   objectSelector:
     matchLabels:
@@ -90,12 +91,13 @@ webhooks:
   sideEffects: None
 - clientConfig:
     caBundle: Cg==
-      service:
-        name: {{ include "resource.controlplane.name" . }}
-        namespace: {{ include "resource.default.namespace" . }}
-        path: /validate-controlplane-cluster-x-k8s-io-v1beta1-kubeadmcontrolplanetemplate
-        port: {{ .Values.ports.webhook }}
+    service:
+      name: {{ include "resource.controlplane.name" . }}
+      namespace: {{ include "resource.default.namespace" . }}
+      path: /validate-controlplane-cluster-x-k8s-io-v1beta1-kubeadmcontrolplanetemplate
+      port: {{ .Values.ports.webhook }}
   failurePolicy: Fail
+  matchPolicy: Equivalent
   name: validation.kubeadmcontrolplanetemplate.controlplane.cluster.x-k8s.io
   objectSelector:
     matchLabels:

--- a/helm/cluster-api/templates/controlplane/webhook.yaml
+++ b/helm/cluster-api/templates/controlplane/webhook.yaml
@@ -12,7 +12,7 @@ webhooks:
     service:
       name: {{ include "resource.controlplane.name" . }}
       namespace: {{ include "resource.default.namespace" . }}
-      path: /mutate-controlplane-cluster-x-k8s-io-v1alpha4-kubeadmcontrolplane
+      path: /mutate-controlplane-cluster-x-k8s-io-v1beta1-kubeadmcontrolplane
       port: {{ .Values.ports.webhook }}
   failurePolicy: Fail
   matchPolicy: Equivalent
@@ -24,13 +24,36 @@ webhooks:
   - apiGroups:
     - controlplane.cluster.x-k8s.io
     apiVersions:
-    - v1alpha4
+    - v1beta1
     operations:
     - CREATE
     - UPDATE
     resources:
     - kubeadmcontrolplanes
   sideEffects: None
+- clientConfig:
+    caBundle: Cg==
+      service:
+        name: {{ include "resource.controlplane.name" . }}
+        namespace: {{ include "resource.default.namespace" . }}
+        path: /mutate-controlplane-cluster-x-k8s-io-v1beta1-kubeadmcontrolplanetemplate
+        port: {{ .Values.ports.webhook }}
+    failurePolicy: Fail
+    name: default.kubeadmcontrolplanetemplate.controlplane.cluster.x-k8s.io
+    objectSelector:
+      matchLabels:
+        cluster.x-k8s.io/watch-filter: {{ .Values.watchfilter }}
+    rules:
+    - apiGroups:
+      - controlplane.cluster.x-k8s.io
+      apiVersions:
+      - v1beta1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - kubeadmcontrolplanetemplates
+    sideEffects: None
 ---
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
@@ -46,7 +69,7 @@ webhooks:
     service:
       name: {{ include "resource.controlplane.name" . }}
       namespace: {{ include "resource.default.namespace" . }}
-      path: /validate-controlplane-cluster-x-k8s-io-v1alpha4-kubeadmcontrolplane
+      path: /validate-controlplane-cluster-x-k8s-io-v1beta1-kubeadmcontrolplane
       port: {{ .Values.ports.webhook }}
   failurePolicy: Fail
   matchPolicy: Equivalent
@@ -58,10 +81,33 @@ webhooks:
   - apiGroups:
     - controlplane.cluster.x-k8s.io
     apiVersions:
-    - v1alpha4
+    - v1beta1
     operations:
     - CREATE
     - UPDATE
     resources:
     - kubeadmcontrolplanes
   sideEffects: None
+- clientConfig:
+    caBundle: Cg==
+      service:
+        name: {{ include "resource.controlplane.name" . }}
+        namespace: {{ include "resource.default.namespace" . }}
+        path: /validate-controlplane-cluster-x-k8s-io-v1beta1-kubeadmcontrolplanetemplate
+        port: {{ .Values.ports.webhook }}
+    failurePolicy: Fail
+    name: validation.kubeadmcontrolplanetemplate.controlplane.cluster.x-k8s.io
+    objectSelector:
+      matchLabels:
+        cluster.x-k8s.io/watch-filter: {{ .Values.watchfilter }}
+    rules:
+    - apiGroups:
+      - controlplane.cluster.x-k8s.io
+      apiVersions:
+      - v1beta1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - kubeadmcontrolplanetemplates
+    sideEffects: None

--- a/helm/cluster-api/templates/controlplane/webhook.yaml
+++ b/helm/cluster-api/templates/controlplane/webhook.yaml
@@ -33,11 +33,11 @@ webhooks:
   sideEffects: None
 - clientConfig:
     caBundle: Cg==
-      service:
-        name: {{ include "resource.controlplane.name" . }}
-        namespace: {{ include "resource.default.namespace" . }}
-        path: /mutate-controlplane-cluster-x-k8s-io-v1beta1-kubeadmcontrolplanetemplate
-        port: {{ .Values.ports.webhook }}
+    service:
+      name: {{ include "resource.controlplane.name" . }}
+      namespace: {{ include "resource.default.namespace" . }}
+      path: /mutate-controlplane-cluster-x-k8s-io-v1beta1-kubeadmcontrolplanetemplate
+      port: {{ .Values.ports.webhook }}
   failurePolicy: Fail
   name: default.kubeadmcontrolplanetemplate.controlplane.cluster.x-k8s.io
   objectSelector:

--- a/helm/cluster-api/templates/controlplane/webhook.yaml
+++ b/helm/cluster-api/templates/controlplane/webhook.yaml
@@ -38,22 +38,22 @@ webhooks:
         namespace: {{ include "resource.default.namespace" . }}
         path: /mutate-controlplane-cluster-x-k8s-io-v1beta1-kubeadmcontrolplanetemplate
         port: {{ .Values.ports.webhook }}
-    failurePolicy: Fail
-    name: default.kubeadmcontrolplanetemplate.controlplane.cluster.x-k8s.io
-    objectSelector:
-      matchLabels:
-        cluster.x-k8s.io/watch-filter: {{ .Values.watchfilter }}
-    rules:
-    - apiGroups:
-      - controlplane.cluster.x-k8s.io
-      apiVersions:
-      - v1beta1
-      operations:
-      - CREATE
-      - UPDATE
-      resources:
-      - kubeadmcontrolplanetemplates
-    sideEffects: None
+  failurePolicy: Fail
+  name: default.kubeadmcontrolplanetemplate.controlplane.cluster.x-k8s.io
+  objectSelector:
+    matchLabels:
+      cluster.x-k8s.io/watch-filter: {{ .Values.watchfilter }}
+  rules:
+  - apiGroups:
+    - controlplane.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - kubeadmcontrolplanetemplates
+  sideEffects: None
 ---
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
@@ -95,19 +95,19 @@ webhooks:
         namespace: {{ include "resource.default.namespace" . }}
         path: /validate-controlplane-cluster-x-k8s-io-v1beta1-kubeadmcontrolplanetemplate
         port: {{ .Values.ports.webhook }}
-    failurePolicy: Fail
-    name: validation.kubeadmcontrolplanetemplate.controlplane.cluster.x-k8s.io
-    objectSelector:
-      matchLabels:
-        cluster.x-k8s.io/watch-filter: {{ .Values.watchfilter }}
-    rules:
-    - apiGroups:
-      - controlplane.cluster.x-k8s.io
-      apiVersions:
-      - v1beta1
-      operations:
-      - CREATE
-      - UPDATE
-      resources:
-      - kubeadmcontrolplanetemplates
-    sideEffects: None
+  failurePolicy: Fail
+  name: validation.kubeadmcontrolplanetemplate.controlplane.cluster.x-k8s.io
+  objectSelector:
+    matchLabels:
+      cluster.x-k8s.io/watch-filter: {{ .Values.watchfilter }}
+  rules:
+  - apiGroups:
+    - controlplane.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - kubeadmcontrolplanetemplates
+  sideEffects: None

--- a/helm/cluster-api/templates/core/mutating-webhook.yaml
+++ b/helm/cluster-api/templates/core/mutating-webhook.yaml
@@ -13,7 +13,7 @@ webhooks:
     service:
       name: {{ include "resource.core.name" . }}
       namespace: {{ include "resource.default.namespace" . }}
-      path: /mutate-cluster-x-k8s-io-v1alpha4-cluster
+      path: /mutate-cluster-x-k8s-io-v1beta1-cluster
       port: {{ .Values.ports.webhook }}
   failurePolicy: Fail
   matchPolicy: Equivalent
@@ -25,7 +25,7 @@ webhooks:
   - apiGroups:
     - cluster.x-k8s.io
     apiVersions:
-    - v1alpha4
+    - v1beta1
     operations:
     - CREATE
     - UPDATE
@@ -37,7 +37,7 @@ webhooks:
     service:
       name: {{ include "resource.core.name" . }}
       namespace: {{ include "resource.default.namespace" . }}
-      path: /mutate-cluster-x-k8s-io-v1alpha4-clusterclass
+      path: /mutate-cluster-x-k8s-io-v1beta1-clusterclass
       port: {{ .Values.ports.webhook }}
   failurePolicy: Fail
   matchPolicy: Equivalent
@@ -49,7 +49,7 @@ webhooks:
   - apiGroups:
     - cluster.x-k8s.io
     apiVersions:
-    - v1alpha4
+    - v1beta1
     operations:
     - CREATE
     - UPDATE
@@ -61,7 +61,7 @@ webhooks:
     service:
       name: {{ include "resource.core.name" . }}
       namespace: {{ include "resource.default.namespace" . }}
-      path: /mutate-cluster-x-k8s-io-v1alpha4-machine
+      path: /mutate-cluster-x-k8s-io-v1beta1-machine
       port: {{ .Values.ports.webhook }}
   failurePolicy: Fail
   matchPolicy: Equivalent
@@ -73,7 +73,7 @@ webhooks:
   - apiGroups:
     - cluster.x-k8s.io
     apiVersions:
-    - v1alpha4
+    - v1beta1
     operations:
     - CREATE
     - UPDATE
@@ -85,7 +85,7 @@ webhooks:
     service:
       name: {{ include "resource.core.name" . }}
       namespace: {{ include "resource.default.namespace" . }}
-      path: /mutate-cluster-x-k8s-io-v1alpha4-machinedeployment
+      path: /mutate-cluster-x-k8s-io-v1beta1-machinedeployment
       port: {{ .Values.ports.webhook }}
   failurePolicy: Fail
   matchPolicy: Equivalent
@@ -97,7 +97,7 @@ webhooks:
   - apiGroups:
     - cluster.x-k8s.io
     apiVersions:
-    - v1alpha4
+    - v1beta1
     operations:
     - CREATE
     - UPDATE
@@ -109,7 +109,7 @@ webhooks:
     service:
       name: {{ include "resource.core.name" . }}
       namespace: {{ include "resource.default.namespace" . }}
-      path: /mutate-cluster-x-k8s-io-v1alpha4-machinehealthcheck
+      path: /mutate-cluster-x-k8s-io-v1beta1-machinehealthcheck
       port: {{ .Values.ports.webhook }}
   failurePolicy: Fail
   matchPolicy: Equivalent
@@ -121,7 +121,7 @@ webhooks:
   - apiGroups:
     - cluster.x-k8s.io
     apiVersions:
-    - v1alpha4
+    - v1beta1
     operations:
     - CREATE
     - UPDATE
@@ -133,7 +133,7 @@ webhooks:
     service:
       name: {{ include "resource.core.name" . }}
       namespace: {{ include "resource.default.namespace" . }}
-      path: /mutate-cluster-x-k8s-io-v1alpha4-machineset
+      path: /mutate-cluster-x-k8s-io-v1beta1-machineset
       port: {{ .Values.ports.webhook }}
   failurePolicy: Fail
   matchPolicy: Equivalent
@@ -145,7 +145,7 @@ webhooks:
   - apiGroups:
     - cluster.x-k8s.io
     apiVersions:
-    - v1alpha4
+    - v1beta1
     operations:
     - CREATE
     - UPDATE
@@ -157,7 +157,7 @@ webhooks:
     service:
       name: {{ include "resource.core.name" . }}
       namespace: {{ include "resource.default.namespace" . }}
-      path: /mutate-cluster-x-k8s-io-v1alpha4-machinepool
+      path: /mutate-cluster-x-k8s-io-v1beta1-machinepool
       port: {{ .Values.ports.webhook }}
   failurePolicy: Fail
   matchPolicy: Equivalent
@@ -169,7 +169,7 @@ webhooks:
   - apiGroups:
     - cluster.x-k8s.io
     apiVersions:
-    - v1alpha4
+    - v1beta1
     operations:
     - CREATE
     - UPDATE
@@ -181,7 +181,7 @@ webhooks:
     service:
       name: {{ include "resource.core.name" . }}
       namespace: {{ include "resource.default.namespace" . }}
-      path: /mutate-addons-cluster-x-k8s-io-v1alpha4-clusterresourceset
+      path: /mutate-addons-cluster-x-k8s-io-v1beta1-clusterresourceset
       port: {{ .Values.ports.webhook }}
   failurePolicy: Fail
   matchPolicy: Equivalent
@@ -193,7 +193,7 @@ webhooks:
   - apiGroups:
     - addons.cluster.x-k8s.io
     apiVersions:
-    - v1alpha4
+    - v1beta1
     operations:
     - CREATE
     - UPDATE

--- a/helm/cluster-api/templates/core/validating-webhook.yaml
+++ b/helm/cluster-api/templates/core/validating-webhook.yaml
@@ -13,7 +13,7 @@ webhooks:
     service:
       name: {{ include "resource.core.name" . }}
       namespace: {{ include "resource.default.namespace" . }}
-      path: /validate-cluster-x-k8s-io-v1alpha4-cluster
+      path: /validate-cluster-x-k8s-io-v1beta1-cluster
       port: {{ .Values.ports.webhook }}
   failurePolicy: Fail
   matchPolicy: Equivalent
@@ -25,7 +25,7 @@ webhooks:
   - apiGroups:
     - cluster.x-k8s.io
     apiVersions:
-    - v1alpha4
+    - v1beta1
     operations:
     - CREATE
     - UPDATE
@@ -37,7 +37,7 @@ webhooks:
     service:
       name: {{ include "resource.core.name" . }}
       namespace: {{ include "resource.default.namespace" . }}
-      path: /validate-cluster-x-k8s-io-v1alpha4-clusterclass
+      path: /validate-cluster-x-k8s-io-v1beta1-clusterclass
       port: {{ .Values.ports.webhook }}
   failurePolicy: Fail
   matchPolicy: Equivalent
@@ -49,7 +49,7 @@ webhooks:
   - apiGroups:
     - cluster.x-k8s.io
     apiVersions:
-    - v1alpha4
+    - v1beta1
     operations:
     - CREATE
     - UPDATE
@@ -61,7 +61,7 @@ webhooks:
     service:
       name: {{ include "resource.core.name" . }}
       namespace: {{ include "resource.default.namespace" . }}
-      path: /validate-cluster-x-k8s-io-v1alpha4-machine
+      path: /validate-cluster-x-k8s-io-v1beta1-machine
       port: {{ .Values.ports.webhook }}
   failurePolicy: Fail
   matchPolicy: Equivalent
@@ -73,7 +73,7 @@ webhooks:
   - apiGroups:
     - cluster.x-k8s.io
     apiVersions:
-    - v1alpha4
+    - v1beta1
     operations:
     - CREATE
     - UPDATE
@@ -85,7 +85,7 @@ webhooks:
     service:
       name: {{ include "resource.core.name" . }}
       namespace: {{ include "resource.default.namespace" . }}
-      path: /validate-cluster-x-k8s-io-v1alpha4-machinedeployment
+      path: /validate-cluster-x-k8s-io-v1beta1-machinedeployment
       port: {{ .Values.ports.webhook }}
   failurePolicy: Fail
   matchPolicy: Equivalent
@@ -97,7 +97,7 @@ webhooks:
   - apiGroups:
     - cluster.x-k8s.io
     apiVersions:
-    - v1alpha4
+    - v1beta1
     operations:
     - CREATE
     - UPDATE
@@ -109,7 +109,7 @@ webhooks:
     service:
       name: {{ include "resource.core.name" . }}
       namespace: {{ include "resource.default.namespace" . }}
-      path: /validate-cluster-x-k8s-io-v1alpha4-machinehealthcheck
+      path: /validate-cluster-x-k8s-io-v1beta1-machinehealthcheck
       port: {{ .Values.ports.webhook }}
   failurePolicy: Fail
   matchPolicy: Equivalent
@@ -121,7 +121,7 @@ webhooks:
   - apiGroups:
     - cluster.x-k8s.io
     apiVersions:
-    - v1alpha4
+    - v1beta1
     operations:
     - CREATE
     - UPDATE
@@ -133,7 +133,7 @@ webhooks:
     service:
       name: {{ include "resource.core.name" . }}
       namespace: {{ include "resource.default.namespace" . }}
-      path: /validate-cluster-x-k8s-io-v1alpha4-machineset
+      path: /validate-cluster-x-k8s-io-v1beta1-machineset
       port: {{ .Values.ports.webhook }}
   failurePolicy: Fail
   matchPolicy: Equivalent
@@ -145,7 +145,7 @@ webhooks:
   - apiGroups:
     - cluster.x-k8s.io
     apiVersions:
-    - v1alpha4
+    - v1beta1
     operations:
     - CREATE
     - UPDATE
@@ -157,7 +157,7 @@ webhooks:
     service:
       name: {{ include "resource.core.name" . }}
       namespace: {{ include "resource.default.namespace" . }}
-      path: /validate-cluster-x-k8s-io-v1alpha4-machinepool
+      path: /validate-cluster-x-k8s-io-v1beta1-machinepool
       port: {{ .Values.ports.webhook }}
   failurePolicy: Fail
   matchPolicy: Equivalent
@@ -169,7 +169,7 @@ webhooks:
   - apiGroups:
     - cluster.x-k8s.io
     apiVersions:
-    - v1alpha4
+    - v1beta1
     operations:
     - CREATE
     - UPDATE
@@ -181,7 +181,7 @@ webhooks:
     service:
       name: {{ include "resource.core.name" . }}
       namespace: {{ include "resource.default.namespace" . }}
-      path: /validate-addons-cluster-x-k8s-io-v1alpha4-clusterresourceset
+      path: /validate-addons-cluster-x-k8s-io-v1beta1-clusterresourceset
       port: {{ .Values.ports.webhook }}
   failurePolicy: Fail
   matchPolicy: Equivalent
@@ -193,7 +193,7 @@ webhooks:
   - apiGroups:
     - addons.cluster.x-k8s.io
     apiVersions:
-    - v1alpha4
+    - v1beta1
     operations:
     - CREATE
     - UPDATE

--- a/helm/cluster-api/values.yaml
+++ b/helm/cluster-api/values.yaml
@@ -10,7 +10,7 @@ images:
     name: giantswarm/kubeadm-bootstrap-controller
   controlplane:
     name: giantswarm/kubeadm-control-plane-controller
-  tag: v0.4.1
+  tag: v1.1.0-gsalpha.2
 
 featuregates:
   machinepool: true


### PR DESCRIPTION
Closes https://github.com/giantswarm/roadmap/issues/670

<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

This PR:

- Updates CAPI version to v1.1.0-gsalpha.2 from our fork.

### Testing

Description on how {APP-NAME} can be tested.

- [ ] fresh install works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM
- [ ] upgrade from previous version works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM

#### Other testing

Description of features to additionally test for {APP-NAME} installations.

- [ ] check reconciliation of existing resources after upgrading
- [ ] X still works after upgrade
- [ ] Y is installed correctly

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
