### PR TITLE
Don't remove 'crd-install' job when it fails to allow debugging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Don't remove `crd-install` job when it fails to allow debugging.
+
 ## [1.1.0] - 2022-05-13
 
 ### Added

--- a/helm/cluster-api/templates/_helpers.tpl
+++ b/helm/cluster-api/templates/_helpers.tpl
@@ -10,7 +10,7 @@
 
 {{- define "cluster-api.CRDInstallAnnotations" -}}
 "helm.sh/hook": "pre-install,pre-upgrade"
-"helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
+"helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 {{- end -}}
 
 {{- define "cluster-api.selectorLabels" -}}


### PR DESCRIPTION
This PR:

- Don't remove `crd-install` job when it fails to allow debugging

### Checklist

- [X] Update changelog in CHANGELOG.md.
