### PR TITLE
Bumped version to v1.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Upgraded to cluster-api v1.1.4
+
+### Added
+
+- Configurable image registry via `.images.registry` value
+
 ## [1.1.0] - 2022-05-24
 
 ### Added

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -27,3 +27,10 @@ verify: generate
 		git diff; \
 		echo "generated files are out of date, run make generate"; exit 1; \
 	fi
+
+ensure-schema-gen:
+	@helm schema-gen --help &>/dev/null || helm plugin install https://github.com/mihaisee/helm-schema-gen.git
+
+.PHONY: schema-gen
+schema-gen: ensure-schema-gen ## Generates the values schema file
+	@cd helm/cluster-api && helm schema-gen values.yaml > values.schema.json

--- a/helm/cluster-api/templates/apps_v1_deployment_capi-controller-manager.yaml
+++ b/helm/cluster-api/templates/apps_v1_deployment_capi-controller-manager.yaml
@@ -34,7 +34,7 @@ spec:
         - --v=0
         command:
         - /manager
-        image: '{{.Values.images.core.name}}:{{.Values.images.tag}}'
+        image: '{{ .Values.images.registry }}/{{.Values.images.core.name}}:{{.Values.images.tag}}'
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/helm/cluster-api/templates/apps_v1_deployment_capi-kubeadm-bootstrap-controller-manager.yaml
+++ b/helm/cluster-api/templates/apps_v1_deployment_capi-kubeadm-bootstrap-controller-manager.yaml
@@ -34,7 +34,7 @@ spec:
         - --v=0
         command:
         - /manager
-        image: '{{.Values.images.bootstrap.name}}:{{.Values.images.tag}}'
+        image: '{{ .Values.images.registry }}/{{.Values.images.bootstrap.name}}:{{.Values.images.tag}}'
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/helm/cluster-api/templates/apps_v1_deployment_capi-kubeadm-control-plane-controller-manager.yaml
+++ b/helm/cluster-api/templates/apps_v1_deployment_capi-kubeadm-control-plane-controller-manager.yaml
@@ -34,7 +34,7 @@ spec:
         - --v=0
         command:
         - /manager
-        image: '{{.Values.images.controlplane.name}}:{{.Values.images.tag}}'
+        image: '{{ .Values.images.registry }}/{{.Values.images.controlplane.name}}:{{.Values.images.tag}}'
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/helm/cluster-api/templates/crd-install/crd-job.yaml
+++ b/helm/cluster-api/templates/crd-install/crd-job.yaml
@@ -28,7 +28,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: kubectl
-        image: "{{ .Values.registry.domain }}/giantswarm/docker-kubectl:latest"
+        image: "{{ .Values.images.domain }}/giantswarm/docker-kubectl:latest"
         command:
         - sh
         - -c

--- a/helm/cluster-api/templates/hook-delete-aggregated-roles/job.yaml
+++ b/helm/cluster-api/templates/hook-delete-aggregated-roles/job.yaml
@@ -26,7 +26,7 @@ spec:
         - |
           kubectl delete clusterrole capi-kubeadm-control-plane-aggregated-manager-role --ignore-not-found
           kubectl delete clusterrole capi-aggregated-manager-role --ignore-not-found
-        image: '{{ .Values.registry.domain }}/giantswarm/docker-kubectl:1.23.1'
+        image: '{{ .Values.images.domain }}/giantswarm/docker-kubectl:1.23.1'
         name: delete-roles
       restartPolicy: Never
       serviceAccountName: helm-hook-delete-aggregated-roles

--- a/helm/cluster-api/values.schema.json
+++ b/helm/cluster-api/values.schema.json
@@ -1,0 +1,66 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "crds": {
+            "type": "object",
+            "properties": {
+                "install": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "images": {
+            "type": "object",
+            "properties": {
+                "bootstrap": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "controlplane": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "core": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "registry": {
+                    "type": "string"
+                },
+                "tag": {
+                    "type": "string"
+                }
+            }
+        },
+        "name": {
+            "type": "string"
+        },
+        "project": {
+            "type": "object",
+            "properties": {
+                "branch": {
+                    "type": "string"
+                },
+                "commit": {
+                    "type": "string"
+                }
+            }
+        },
+        "watchFilter": {
+            "type": "string"
+        }
+    }
+}

--- a/helm/cluster-api/values.yaml
+++ b/helm/cluster-api/values.yaml
@@ -1,14 +1,14 @@
 name: cluster-api
-registry:
-  domain: quay.io
+
 images:
+  registry: quay.io
   core:
     name: giantswarm/cluster-api-controller
   bootstrap:
     name: giantswarm/kubeadm-bootstrap-controller
   controlplane:
     name: giantswarm/kubeadm-control-plane-controller
-  tag: v1.0.4-gs1
+  tag: v1.1.4
 
 project:
   branch: "[[ .Branch ]]"


### PR DESCRIPTION
Signed-off-by: Marcus Noble <github@marcusnoble.co.uk>

This PR:

- Upgraded to cluster-api v1.1.4
- Added configurable image registry via `.images.registry` value (Towards https://github.com/giantswarm/giantswarm/issues/22691)
- Added Make target to generate values schema

### Checklist

- [x] Update changelog in CHANGELOG.md.
