### PR TITLE
Use 'kubectl' retagged container image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use `kubectl` container retagged image. 
+
 ## [1.5.0] - 2022-07-12
 
 ### Fixed

--- a/helm/cluster-api/templates/crd-install/crd-job.yaml
+++ b/helm/cluster-api/templates/crd-install/crd-job.yaml
@@ -28,7 +28,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: kubectl
-        image: "{{ .Values.images.domain }}/giantswarm/docker-kubectl:1.24.2"
+        image: "{{ .Values.images.domain }}/giantswarm/kubectl:1.24.2"
         command:
         - sh
         - -c

--- a/helm/cluster-api/templates/hook-delete-aggregated-roles/job.yaml
+++ b/helm/cluster-api/templates/hook-delete-aggregated-roles/job.yaml
@@ -26,7 +26,7 @@ spec:
         - |
           kubectl delete clusterrole capi-kubeadm-control-plane-aggregated-manager-role --ignore-not-found
           kubectl delete clusterrole capi-aggregated-manager-role --ignore-not-found
-        image: '{{ .Values.images.domain }}/giantswarm/docker-kubectl:1.23.1'
+        image: '{{ .Values.images.domain }}/giantswarm/kubectl:1.23.1'
         name: delete-roles
       restartPolicy: Never
       serviceAccountName: helm-hook-delete-aggregated-roles

--- a/helm/cluster-api/templates/hook-delete-aggregated-roles/job.yaml
+++ b/helm/cluster-api/templates/hook-delete-aggregated-roles/job.yaml
@@ -26,7 +26,7 @@ spec:
         - |
           kubectl delete clusterrole capi-kubeadm-control-plane-aggregated-manager-role --ignore-not-found
           kubectl delete clusterrole capi-aggregated-manager-role --ignore-not-found
-        image: '{{ .Values.images.domain }}/giantswarm/kubectl:1.23.1'
+        image: '{{ .Values.images.domain }}/giantswarm/kubectl:1.24.2'
         name: delete-roles
       restartPolicy: Never
       serviceAccountName: helm-hook-delete-aggregated-roles


### PR DESCRIPTION
This PR:

- use `kubectl` image managed by retagger

### Checklist

- [X] Update changelog in CHANGELOG.md.
