### PR TITLE
Enable ignition feature gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Enable ignition feature gate.
+
 ## [1.5.1] - 2022-07-13
 
 ### Changed
 
-- Use `kubectl` container retagged image. 
+- Use `kubectl` container retagged image.
 
 ## [1.5.0] - 2022-07-12
 

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -1,6 +1,5 @@
-# Generate kustomize patches and all helm charts
 .PHONY: generate
-generate:
+generate: ## Generate kustomize patches and all helm charts
 	./hack/generate-kustomize-patches.sh
 	$(MAKE) delete-generated-helm-charts
 	kustomize build config/helm -o helm/cluster-api/templates

--- a/config/helm/deployment-args.yaml
+++ b/config/helm/deployment-args.yaml
@@ -27,7 +27,7 @@ spec:
         - name: manager
           args:
             - --metrics-bind-addr=0.0.0.0:8080
-            - --feature-gates=MachinePool=true
+            - --feature-gates=MachinePool=true,KubeadmBootstrapFormatIgnition=true
             - --watch-filter={{ .Values.watchFilter }}
             - --v=0
 
@@ -44,6 +44,6 @@ spec:
         - name: manager
           args:
             - --metrics-bind-addr=0.0.0.0:8080
-            - --feature-gates=ClusterTopology=true
+            - --feature-gates=ClusterTopology=true,KubeadmBootstrapFormatIgnition=true
             - --watch-filter={{ .Values.watchFilter }}
             - --v=0

--- a/helm/cluster-api/templates/apps_v1_deployment_capi-kubeadm-bootstrap-controller-manager.yaml
+++ b/helm/cluster-api/templates/apps_v1_deployment_capi-kubeadm-bootstrap-controller-manager.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
       - args:
         - --metrics-bind-addr=0.0.0.0:8080
-        - --feature-gates=MachinePool=true
+        - --feature-gates=MachinePool=true,KubeadmBootstrapFormatIgnition=true
         - --watch-filter={{ .Values.watchFilter }}
         - --v=0
         command:

--- a/helm/cluster-api/templates/apps_v1_deployment_capi-kubeadm-control-plane-controller-manager.yaml
+++ b/helm/cluster-api/templates/apps_v1_deployment_capi-kubeadm-control-plane-controller-manager.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
       - args:
         - --metrics-bind-addr=0.0.0.0:8080
-        - --feature-gates=ClusterTopology=true
+        - --feature-gates=ClusterTopology=true,KubeadmBootstrapFormatIgnition=true
         - --watch-filter={{ .Values.watchFilter }}
         - --v=0
         command:


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/778

From the cluster initialised with `export EXP_KUBEADM_BOOTSTRAP_FORMAT_IGNITION=true clusterctl init ...`:

```
$ k get pod -n capi-system -o yaml | grep feature
      - --feature-gates=MachinePool=false,ClusterResourceSet=false,ClusterTopology=false

$ k get pod -n capi-kubeadm-control-plane-system -o yaml | grep feature
      - --feature-gates=ClusterTopology=false,KubeadmBootstrapFormatIgnition=true

$ k get pod -n capi-kubeadm-bootstrap-system -o yaml | grep feature
      - --feature-gates=MachinePool=false,KubeadmBootstrapFormatIgnition=true
```