### PR TITLE
Update giantswarm/kubectl version to v1.24.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update `giantswarm/kubectl` (used for installing CRDs) version to v1.24.9.
+
 ## [1.8.3] - 2023-01-06
 
 ### Changed

--- a/helm/cluster-api/templates/crd-install/crd-job.yaml
+++ b/helm/cluster-api/templates/crd-install/crd-job.yaml
@@ -28,7 +28,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: kubectl
-        image: "{{ .Values.images.domain }}/giantswarm/kubectl:1.24.2"
+        image: "{{ .Values.images.domain }}/giantswarm/kubectl:1.24.9"
         command:
         - sh
         - -c


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/1877

This PR:

- Updates `giantswarm/kubectl` version to v1.24.9 (the latest v1.24.x patch version). This is used for installing CRDs.

### Checklist

- [x] Update changelog in CHANGELOG.md.
