### PR TITLE
Remove `string null` `creationTimestamp` field to avoid breaking installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Remove known broken `creationTimestamp: "null"` fields that kustomize 5.0.0+ is rendering as string rather than `nil` values
+
 ## [1.9.0] - 2023-01-25
 
 ### Changed

--- a/config/helm/kustomization.yaml
+++ b/config/helm/kustomization.yaml
@@ -70,3 +70,9 @@ patches:
     target:
       kind: CustomResourceDefinition
       labelSelector: cluster.x-k8s.io/provider=control-plane-kubeadm
+  - target:
+      kind: CustomResourceDefinition
+      name: (ipaddressclaims\.ipam|extensionconfigs\.runtime|ipaddresses\.ipam).cluster.x-k8s.io
+    patch: |-
+      - op: remove
+        path: /metadata/creationTimestamp

--- a/helm/cluster-api/files/core/bases/extensionconfigs.runtime.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api/files/core/bases/extensionconfigs.runtime.cluster.x-k8s.io.yaml
@@ -4,7 +4,6 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/capi-serving-cert'
     controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: "null"
   labels:
     app.giantswarm.io/branch: '{{ .Values.project.branch }}'
     app.giantswarm.io/commit: '{{ .Values.project.commit }}'

--- a/helm/cluster-api/files/core/bases/ipaddressclaims.ipam.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api/files/core/bases/ipaddressclaims.ipam.cluster.x-k8s.io.yaml
@@ -4,7 +4,6 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/capi-serving-cert'
     controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: "null"
   labels:
     app.giantswarm.io/branch: '{{ .Values.project.branch }}'
     app.giantswarm.io/commit: '{{ .Values.project.commit }}'

--- a/helm/cluster-api/files/core/bases/ipaddresses.ipam.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api/files/core/bases/ipaddresses.ipam.cluster.x-k8s.io.yaml
@@ -4,7 +4,6 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/capi-serving-cert'
     controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: "null"
   labels:
     app.giantswarm.io/branch: '{{ .Values.project.branch }}'
     app.giantswarm.io/commit: '{{ .Values.project.commit }}'


### PR DESCRIPTION
This PR:

fixes the `string "null"` creationTimestamp field by removing it - same as https://github.com/giantswarm/cluster-api-provider-azure-app/pull/98

### Checklist

- [ ] Update changelog in CHANGELOG.md.
