### PR TITLE
Add team annotation to chart

### DIFF
--- a/helm/cluster-api/Chart.yaml
+++ b/helm/cluster-api/Chart.yaml
@@ -5,23 +5,5 @@ home: "https://github.com/giantswarm/cluster-api-app"
 version: "[[ .Version ]]"
 appVersion: [[ .AppVersion ]]
 annotations:
-  application.giantswarm.io/owners: |
-    - catalog: default
-      provider: capa
-      team: hydra
-    - catalog: default
-      provider: gcp
-      team: hydra
-    - catalog: default
-      provider: azure
-      team: clippy
-    - catalog: default
-      provider: openstack
-      team: rocket
-    - catalog: default
-      provider: cloud-director
-      team: rocket
-    - catalog: default
-      provider: vsphere
-      team: rocket
+  application.giantswarm.io/team: turtles
   config.giantswarm.io/version: 1.x.x


### PR DESCRIPTION
The team annotation is required, otherwise the alert `AppWithoutTeamAnnotation` will fire.

### Checklist

- [ ] Update changelog in CHANGELOG.md.
