### PR TITLE
Add common labels to pods so that Hubble shows the app name

### DIFF
--- a/config/helm/common-labels.yaml
+++ b/config/helm/common-labels.yaml
@@ -14,3 +14,6 @@ labels:
 fieldSpecs:
   - path: metadata/labels
     create: true
+  - path: spec/template/metadata/labels
+    create: true
+    kind: Deployment

--- a/helm/cluster-api/templates/apps_v1_deployment_capi-controller-manager.yaml
+++ b/helm/cluster-api/templates/apps_v1_deployment_capi-controller-manager.yaml
@@ -23,8 +23,15 @@ spec:
   template:
     metadata:
       labels:
+        app.giantswarm.io/branch: '{{ .Values.project.branch }}'
+        app.giantswarm.io/commit: '{{ .Values.project.commit }}'
+        app.kubernetes.io/instance: '{{ .Release.Name }}'
+        app.kubernetes.io/managed-by: '{{ .Release.Service }}'
+        app.kubernetes.io/name: cluster-api
+        app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
         cluster.x-k8s.io/provider: cluster-api
         control-plane: controller-manager
+        helm.sh/chart: cluster-api
     spec:
       containers:
       - args:

--- a/helm/cluster-api/templates/apps_v1_deployment_capi-kubeadm-bootstrap-controller-manager.yaml
+++ b/helm/cluster-api/templates/apps_v1_deployment_capi-kubeadm-bootstrap-controller-manager.yaml
@@ -23,8 +23,15 @@ spec:
   template:
     metadata:
       labels:
+        app.giantswarm.io/branch: '{{ .Values.project.branch }}'
+        app.giantswarm.io/commit: '{{ .Values.project.commit }}'
+        app.kubernetes.io/instance: '{{ .Release.Name }}'
+        app.kubernetes.io/managed-by: '{{ .Release.Service }}'
+        app.kubernetes.io/name: cluster-api
+        app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
         cluster.x-k8s.io/provider: bootstrap-kubeadm
         control-plane: controller-manager
+        helm.sh/chart: cluster-api
     spec:
       containers:
       - args:

--- a/helm/cluster-api/templates/apps_v1_deployment_capi-kubeadm-control-plane-controller-manager.yaml
+++ b/helm/cluster-api/templates/apps_v1_deployment_capi-kubeadm-control-plane-controller-manager.yaml
@@ -23,8 +23,15 @@ spec:
   template:
     metadata:
       labels:
+        app.giantswarm.io/branch: '{{ .Values.project.branch }}'
+        app.giantswarm.io/commit: '{{ .Values.project.commit }}'
+        app.kubernetes.io/instance: '{{ .Release.Name }}'
+        app.kubernetes.io/managed-by: '{{ .Release.Service }}'
+        app.kubernetes.io/name: cluster-api
+        app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
         cluster.x-k8s.io/provider: control-plane-kubeadm
         control-plane: controller-manager
+        helm.sh/chart: cluster-api
     spec:
       containers:
       - args:


### PR DESCRIPTION
Same as https://github.com/giantswarm/cluster-api-provider-aws-app/pull/171: Cilium's user interface Hubble shows the application name and its network flow correctly after this change becausethe pods are now labeled.

### Checklist

- [x] Update changelog in CHANGELOG.md.
