### PR TITLE
Configure gsoci.azurecr.io as the registry to use by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Configure `gsoci.azurecr.io` as the default container image registry.
 - Upgrade CAPI to v1.4.7
 
 ## [1.14.1] - 2023-09-20

--- a/helm/cluster-api/values.yaml
+++ b/helm/cluster-api/values.yaml
@@ -1,7 +1,7 @@
 name: cluster-api
 
 images:
-  domain: docker.io
+  domain: gsoci.azurecr.io
   core:
     name: giantswarm/cluster-api-controller
   bootstrap:


### PR DESCRIPTION
Towards

- https://github.com/giantswarm/roadmap/issues/3017

This PR replaces any occurrence of `docker.io` in `values.yaml` files with `gsoci.azurecr.io`,
to make the new ACR registry the default one.
