### PR TITLE
Make: Use `kubectl` integrated `kustomize`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Make: Use `kubectl` integrated `kustomize`. ([#171](https://github.com/giantswarm/cluster-api-app/pull/171))
+
 ## [1.15.0] - 2023-12-20
 
 ### Changed

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -2,7 +2,7 @@
 generate: ## Generate kustomize patches and all helm charts
 	./hack/fetch-manifest.sh
 	$(MAKE) delete-generated-helm-charts
-	kustomize build config/helm -o helm/cluster-api/templates
+	kubectl kustomize config/helm -o helm/cluster-api/templates
 	rm -v helm/cluster-api/templates/v1_configmap_watchfilter-patch.yaml
 	./hack/move-generated-crds.sh
 	./hack/generate-crd-version-patches.sh
@@ -19,7 +19,7 @@ $(CRD_BUILD_DIR):
 .PHONY: release-manifests
 release-manifests: $(CRD_BUILD_DIR) ## Builds the manifests to publish with a release
 	# Build core-components.
-	kustomize build config/helm/files > $(CRD_BUILD_DIR)/crds.yaml
+	kubectl kustomize config/helm/files > $(CRD_BUILD_DIR)/crds.yaml
 
 .PHONY: verify
 verify: generate

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is a meta App that provides deployment packaging for Cluster API core, boot
 
 To get all the `make targets` run
 
-* `kustomize` ([source](https://github.com/kubernetes-sigs/kustomize/releases)) in version `>= v5.0` is needed
+* `kubectl` ([source](https://github.com/kubernetes/kubectl)) in version `>= v1.27.0` is needed
 * `yq` ([source](https://github.com/mikefarah/yq/)) is needed
 
 ## How it works
@@ -16,7 +16,7 @@ To get all the `make targets` run
 The `make` target `generate` transfer the upstream released `cluster-api-components.yaml` into a Giant Swarm specific `HelmChart`.
 Beside the transformation into a `HelmChart` there are few other changes needed to make all the `cluster-api` components fit well into our stack.
 
-To make all the changes transparent and reproducible, `kustomize` is used to apply (mostly) all changes.
+To make all the changes transparent and reproducible, `kubectl kustomize` is used to apply (mostly) all changes.
 
 Following notable commands/scripts are triggered in `make generate`:
 
@@ -24,7 +24,7 @@ Following notable commands/scripts are triggered in `make generate`:
     Fetch the release manifest with the version specified in `helm/cluster-api/values.yaml`. Since we use our own fork of CAPI which does not replicate upstream GitHub releases, the YAML manifest is part of the Docker image as means to easily fetch the manifest which exactly matches the desired commit/tag.
 1. `make delete-generated-helm-charts`</br>
     Cleans folder `helm/cluster-api/templates` to not get any orphaned objects in the app.
-1. `kustomize build config/helm -o helm/cluster-api/templates`</br>
+1. `kubectl kustomize config/helm -o helm/cluster-api/templates`</br>
     Apply all the defined `kustomize` changes (defined in `kustomization.yaml`)
 1. [`hack/move-generated-crds.sh`](hack/move-generated-crds.sh)</br>
     Used to move all the `CRDs` into the directory `helm/cluster-api/files`. All files within this directory are later used in `Job/cluster-api-crd-install`.


### PR DESCRIPTION
This PR changes the Makefile to use the `kubectl` integrated `kustomize` instead of the dedicated one. This reduces the toolkit requirements for developers.

### Checklist

- [x] Update changelog in CHANGELOG.md.
