### PR TITLE
Add taint toleration for unitialized nodes and prefer scheduling on control-plane nodes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Change container image registry values name to use values from `config` repo.
+- Add toleration for `node.cluster.x-k8s.io/uninitialized` taint.
+- Remove toleration for old `node-role.kubernetes.io/master` taint.
+- Add node affinity to prefer scheduling CAPI pods to control-plane nodes.
 
 ## [1.15.2] - 2024-01-22
 

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -5,9 +5,9 @@ generate:
 	hack/fetch-manifest.sh
 
 	# Kustomize templates.
-	rm helm/cluster-api/templates/*.yaml
+	rm -f helm/cluster-api/templates/*.yaml
 	kubectl kustomize config/helm --output helm/cluster-api/templates
-	rm helm/cluster-api/templates/v1_configmap_watch-filter.yaml
+	rm -f helm/cluster-api/templates/v1_configmap_watch-filter.yaml
 
 	# Move CRDs.
 	hack/move-crds.sh

--- a/config/helm/patches/deployments/capi-controller-manager.yaml
+++ b/config/helm/patches/deployments/capi-controller-manager.yaml
@@ -8,6 +8,14 @@ metadata:
 spec:
   template:
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            weight: 10
       containers:
       - name: manager
         args:
@@ -19,3 +27,9 @@ spec:
         - name: metrics
           protocol: TCP
           containerPort: 8080
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+      - effect: NoSchedule
+        key: "node.cluster.x-k8s.io/uninitialized"
+        operator: "Exists"

--- a/config/helm/patches/deployments/capi-kubeadm-bootstrap-controller-manager.yaml
+++ b/config/helm/patches/deployments/capi-kubeadm-bootstrap-controller-manager.yaml
@@ -8,6 +8,14 @@ metadata:
 spec:
   template:
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            weight: 10
       containers:
       - name: manager
         args:
@@ -19,3 +27,9 @@ spec:
         - name: metrics
           protocol: TCP
           containerPort: 8080
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+      - effect: NoSchedule
+        key: "node.cluster.x-k8s.io/uninitialized"
+        operator: "Exists"

--- a/config/helm/patches/deployments/capi-kubeadm-control-plane-controller-manager.yaml
+++ b/config/helm/patches/deployments/capi-kubeadm-control-plane-controller-manager.yaml
@@ -8,6 +8,14 @@ metadata:
 spec:
   template:
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            weight: 10
       containers:
       - name: manager
         args:
@@ -19,3 +27,9 @@ spec:
         - name: metrics
           protocol: TCP
           containerPort: 8080
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+      - effect: NoSchedule
+        key: "node.cluster.x-k8s.io/uninitialized"
+        operator: "Exists"

--- a/helm/cluster-api/templates/apps_v1_deployment_capi-controller-manager.yaml
+++ b/helm/cluster-api/templates/apps_v1_deployment_capi-controller-manager.yaml
@@ -33,6 +33,14 @@ spec:
         control-plane: controller-manager
         helm.sh/chart: cluster-api
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            weight: 10
       containers:
       - args:
         - --metrics-bind-addr=0.0.0.0:8080
@@ -96,9 +104,10 @@ spec:
       terminationGracePeriodSeconds: 10
       tolerations:
       - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-      - effect: NoSchedule
         key: node-role.kubernetes.io/control-plane
+      - effect: NoSchedule
+        key: node.cluster.x-k8s.io/uninitialized
+        operator: Exists
       volumes:
       - name: cert
         secret:

--- a/helm/cluster-api/templates/apps_v1_deployment_capi-kubeadm-bootstrap-controller-manager.yaml
+++ b/helm/cluster-api/templates/apps_v1_deployment_capi-kubeadm-bootstrap-controller-manager.yaml
@@ -33,6 +33,14 @@ spec:
         control-plane: controller-manager
         helm.sh/chart: cluster-api
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            weight: 10
       containers:
       - args:
         - --metrics-bind-addr=0.0.0.0:8080
@@ -83,9 +91,10 @@ spec:
       terminationGracePeriodSeconds: 10
       tolerations:
       - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-      - effect: NoSchedule
         key: node-role.kubernetes.io/control-plane
+      - effect: NoSchedule
+        key: node.cluster.x-k8s.io/uninitialized
+        operator: Exists
       volumes:
       - name: cert
         secret:

--- a/helm/cluster-api/templates/apps_v1_deployment_capi-kubeadm-control-plane-controller-manager.yaml
+++ b/helm/cluster-api/templates/apps_v1_deployment_capi-kubeadm-control-plane-controller-manager.yaml
@@ -33,6 +33,14 @@ spec:
         control-plane: controller-manager
         helm.sh/chart: cluster-api
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            weight: 10
       containers:
       - args:
         - --metrics-bind-addr=0.0.0.0:8080
@@ -96,9 +104,10 @@ spec:
       terminationGracePeriodSeconds: 10
       tolerations:
       - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-      - effect: NoSchedule
         key: node-role.kubernetes.io/control-plane
+      - effect: NoSchedule
+        key: node.cluster.x-k8s.io/uninitialized
+        operator: Exists
       volumes:
       - name: cert
         secret:


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/30433

### Add toleration for `node.cluster.x-k8s.io/uninitialized` taint.
 To explain a little bit this change -  this is taint that CAPI adds to new nodes and it will removes it after some checks and if it sees the id in some CRs, this toleration should prevent deadlock when  nodes are rolling in MC - if CAPI pods are not scheduled then  they wont be able to run on new nodes due the taint and the only thing that would remove the taint is not running - so to avoid such scenario we want to introduced the taint toleration for CAPi controllers
  
  
### Remove toleration for old `node-role.kubernetes.io/master` taint.
this old taint is no longer used in any version of CAPi clusters so its fine to remove it. (or more specifically we don't have to add it to the patch)

### Add node affinity to prefer scheduling CAPI pods to control-plane nodes.
Prefer scheduling CAPI pods on control-plane nodes to make some use of the resources,  this is something we want on CAPA/CAPZ, not sure if this is a problem for on-prem providers


### fix makefile
do not fail on `rm` command if the previous execution of make failed.
 This was driving me crazy because if the make command failed before generating the templates it would then fail on next run as `rm xxxx`   fails when files do not exist.