### PR TITLE
Bump capi image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Upgrade CAPI to v1.4.9
 - Change container image registry values name to use values from `config` repo.
 - Add toleration for `node.cluster.x-k8s.io/uninitialized` taint.
 - Remove toleration for old `node-role.kubernetes.io/master` taint.

--- a/helm/cluster-api/values.yaml
+++ b/helm/cluster-api/values.yaml
@@ -10,7 +10,7 @@ images:
     name: giantswarm/kubeadm-bootstrap-controller
   controlplane:
     name: giantswarm/kubeadm-control-plane-controller
-  tag: v1.4.9-gs-83c646759 # upstream v1.4.9 + https://github.com/kubernetes-sigs/cluster-api/pull/8586 (Makefile improvement) + https://github.com/giantswarm/cluster-api/pull/21 (backport of bootstrap config reference rotation support)
+  tag: v1.4.9-gs-83c646759  # upstream v1.4.9 + https://github.com/kubernetes-sigs/cluster-api/pull/8586 (Makefile improvement) + https://github.com/giantswarm/cluster-api/pull/21 (backport of bootstrap config reference rotation support)
 
 project:
   branch: "[[ .Branch ]]"

--- a/helm/cluster-api/values.yaml
+++ b/helm/cluster-api/values.yaml
@@ -10,7 +10,7 @@ images:
     name: giantswarm/kubeadm-bootstrap-controller
   controlplane:
     name: giantswarm/kubeadm-control-plane-controller
-  tag: v1.4.7-gs-61127c250  # upstream v1.4.7 + https://github.com/kubernetes-sigs/cluster-api/pull/8586 (Makefile improvement) + https://github.com/giantswarm/cluster-api/pull/21 (backport of bootstrap config reference rotation support)
+  tag: v1.4.9-gs-83c646759 # upstream v1.4.9 + https://github.com/kubernetes-sigs/cluster-api/pull/8586 (Makefile improvement) + https://github.com/giantswarm/cluster-api/pull/21 (backport of bootstrap config reference rotation support)
 
 project:
   branch: "[[ .Branch ]]"


### PR DESCRIPTION
Addresses issues when updating kubeadmConfigSpec joinConfiguration fields, which were previously prevented by validation webhook in CAPI controllers.