### PR TITLE
Don't inject conversion webhooks to CRDs if they don't have originally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Don't inject conversion webhooks to CRDs if they don't have originally.
+
 ## [1.20.0] - 2024-06-11
 
 ### Changed

--- a/config/helm/kustomization.yaml
+++ b/config/helm/kustomization.yaml
@@ -75,24 +75,32 @@ replacements:
 
 patches:
 # CRDs
+- path: patches/crds/all.yaml
+  target:
+    group: apiextensions.k8s.io
+    version: v1
+    kind: CustomResourceDefinition
 - path: patches/crds/core.yaml
   target:
     group: apiextensions.k8s.io
     version: v1
     kind: CustomResourceDefinition
     labelSelector: cluster.x-k8s.io/provider=cluster-api
+    annotationSelector: cert-manager.io/inject-ca-from
 - path: patches/crds/bootstrap.yaml
   target:
     group: apiextensions.k8s.io
     version: v1
     kind: CustomResourceDefinition
     labelSelector: cluster.x-k8s.io/provider=bootstrap-kubeadm
+    annotationSelector: cert-manager.io/inject-ca-from
 - path: patches/crds/controlplane.yaml
   target:
     group: apiextensions.k8s.io
     version: v1
     kind: CustomResourceDefinition
     labelSelector: cluster.x-k8s.io/provider=control-plane-kubeadm
+    annotationSelector: cert-manager.io/inject-ca-from
 
 # Namespaces
 - path: patches/namespaces/capi-system.yaml

--- a/config/helm/patches/crds/all.yaml
+++ b/config/helm/patches/crds/all.yaml
@@ -1,0 +1,7 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: core
+  labels:
+    clusterctl.cluster.x-k8s.io: ""
+    clusterctl.cluster.x-k8s.io/move: ""

--- a/config/helm/patches/crds/bootstrap.yaml
+++ b/config/helm/patches/crds/bootstrap.yaml
@@ -2,9 +2,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: bootstrap
-  labels:
-    clusterctl.cluster.x-k8s.io: ""
-    clusterctl.cluster.x-k8s.io/move: ""
   annotations:
     cert-manager.io/inject-ca-from: "{{ .Release.Namespace }}/capi-kubeadm-bootstrap-serving-cert"
 spec:

--- a/config/helm/patches/crds/controlplane.yaml
+++ b/config/helm/patches/crds/controlplane.yaml
@@ -2,9 +2,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: controlplane
-  labels:
-    clusterctl.cluster.x-k8s.io: ""
-    clusterctl.cluster.x-k8s.io/move: ""
   annotations:
     cert-manager.io/inject-ca-from: "{{ .Release.Namespace }}/capi-kubeadm-control-plane-serving-cert"
 spec:

--- a/config/helm/patches/crds/core.yaml
+++ b/config/helm/patches/crds/core.yaml
@@ -2,9 +2,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: core
-  labels:
-    clusterctl.cluster.x-k8s.io: ""
-    clusterctl.cluster.x-k8s.io/move: ""
   annotations:
     cert-manager.io/inject-ca-from: "{{ .Release.Namespace }}/capi-serving-cert"
 spec:

--- a/helm/cluster-api/files/core/bases/extensionconfigs.runtime.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api/files/core/bases/extensionconfigs.runtime.cluster.x-k8s.io.yaml
@@ -2,7 +2,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/capi-serving-cert'
     controller-gen.kubebuilder.io/version: v0.13.0
   labels:
     app.kubernetes.io/instance: '{{ .Release.Name }}'
@@ -17,19 +16,6 @@ metadata:
     helm.sh/chart: cluster-api
   name: extensionconfigs.runtime.cluster.x-k8s.io
 spec:
-  conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        caBundle: Cg==
-        service:
-          name: capi-webhook-service
-          namespace: '{{ .Release.Namespace }}'
-          path: /convert
-          port: 443
-      conversionReviewVersions:
-        - v1
-        - v1beta1
   group: runtime.cluster.x-k8s.io
   names:
     categories:

--- a/helm/cluster-api/files/core/bases/ipaddressclaims.ipam.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api/files/core/bases/ipaddressclaims.ipam.cluster.x-k8s.io.yaml
@@ -2,7 +2,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/capi-serving-cert'
     controller-gen.kubebuilder.io/version: v0.13.0
   labels:
     app.kubernetes.io/instance: '{{ .Release.Name }}'
@@ -17,19 +16,6 @@ metadata:
     helm.sh/chart: cluster-api
   name: ipaddressclaims.ipam.cluster.x-k8s.io
 spec:
-  conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        caBundle: Cg==
-        service:
-          name: capi-webhook-service
-          namespace: '{{ .Release.Namespace }}'
-          path: /convert
-          port: 443
-      conversionReviewVersions:
-        - v1
-        - v1beta1
   group: ipam.cluster.x-k8s.io
   names:
     categories:

--- a/helm/cluster-api/files/core/bases/ipaddresses.ipam.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api/files/core/bases/ipaddresses.ipam.cluster.x-k8s.io.yaml
@@ -2,7 +2,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/capi-serving-cert'
     controller-gen.kubebuilder.io/version: v0.13.0
   labels:
     app.kubernetes.io/instance: '{{ .Release.Name }}'
@@ -17,19 +16,6 @@ metadata:
     helm.sh/chart: cluster-api
   name: ipaddresses.ipam.cluster.x-k8s.io
 spec:
-  conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        caBundle: Cg==
-        service:
-          name: capi-webhook-service
-          namespace: '{{ .Release.Namespace }}'
-          path: /convert
-          port: 443
-      conversionReviewVersions:
-        - v1
-        - v1beta1
   group: ipam.cluster.x-k8s.io
   names:
     categories:


### PR DESCRIPTION
We are injecting conversion webhooks to some CRDs when they don't have originally.