### PR TITLE
Kustomization: Delete `metrics` port.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Chart: Rework affinity & tolerations. ([#245](https://github.com/giantswarm/cluster-api-app/pull/245))
 - Hack: Rework `wrap-with-conditional.sh`. ([#246](https://github.com/giantswarm/cluster-api-app/pull/246))
 - Hack: Rename `generate-crd-version-patches.sh`. ([#247](https://github.com/giantswarm/cluster-api-app/pull/247))
+- Kustomization: Delete `metrics` port. ([#248](https://github.com/giantswarm/cluster-api-app/pull/248))
 
 ## [1.20.1] - 2024-07-10
 

--- a/config/helm/kustomization.yaml
+++ b/config/helm/kustomization.yaml
@@ -124,6 +124,11 @@ patches:
 - path: patches/certificates/capi-kubeadm-control-plane-serving-cert.yaml
 
 # Deployments
+- path: patches/deployments/all.yaml
+  target:
+    group: apps
+    version: v1
+    kind: Deployment
 - path: patches/deployments/capi-controller-manager.yaml
 - path: patches/deployments/capi-kubeadm-bootstrap-controller-manager.yaml
 - path: patches/deployments/capi-kubeadm-control-plane-controller-manager.yaml

--- a/config/helm/patches/deployments/all.yaml
+++ b/config/helm/patches/deployments/all.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: all
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        ports:
+        - $patch: delete
+          name: metrics
+          protocol: TCP
+          containerPort: 8443


### PR DESCRIPTION
Mainly fixes the `Templates / Verify` GitHub action, as `make generate` didn't remove the `metrics` port tcp/8443 and we are overriding it with tcp/8080.