### PR TITLE
Chart: Use CAPI v1.8.12-gs-5fe235a73.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Chart: Use CAPI v1.8.12-gs-5fe235a73. ([#269](https://github.com/giantswarm/cluster-api-app/pull/269))
+
 ## [3.0.0] - 2025-05-16
 
 ### Changed

--- a/helm/cluster-api/values.yaml
+++ b/helm/cluster-api/values.yaml
@@ -25,7 +25,7 @@ images:
     # -- Control plane image repository.
     name: giantswarm/kubeadm-control-plane-controller
   # -- Image tag (used for all images).
-  tag: v1.8.12-gs-eb9c128be
+  tag: v1.8.12-gs-5fe235a73
 
 # -- Webhook watch filter.
 watchFilter: capi


### PR DESCRIPTION
The previously used tag `v1.8.12-gs-eb9c128be` has been built from the `release-1.8` branch, which - at this point in time - was synced to the latest state of the upstream `release-1.8` branch instead of just the `v1.8.12` tag and therefore included changes, which have been made after the `v1.8.12` release.

I reset the `release-1.8` branch to `v1.8.12`, which triggered a fresh build, and tagged it as `v1.8.12-gs-5fe235a73`, which this PR is using.