### PR TITLE
Drop dummy `caBundle` field to support Kubernetes 1.31

### DIFF
--- a/config/helm/patches/crds/bootstrap.yaml
+++ b/config/helm/patches/crds/bootstrap.yaml
@@ -12,7 +12,6 @@ spec:
       - v1
       - v1beta1
       clientConfig:
-        caBundle: Cg==
         service:
           name: capi-kubeadm-bootstrap-webhook-service
           namespace: "{{ .Release.Namespace }}"

--- a/config/helm/patches/crds/controlplane.yaml
+++ b/config/helm/patches/crds/controlplane.yaml
@@ -12,7 +12,6 @@ spec:
       - v1
       - v1beta1
       clientConfig:
-        caBundle: Cg==
         service:
           name: capi-kubeadm-control-plane-webhook-service
           namespace: "{{ .Release.Namespace }}"

--- a/config/helm/patches/crds/core.yaml
+++ b/config/helm/patches/crds/core.yaml
@@ -12,7 +12,6 @@ spec:
       - v1
       - v1beta1
       clientConfig:
-        caBundle: Cg==
         service:
           name: capi-webhook-service
           namespace: "{{ .Release.Namespace }}"

--- a/helm/cluster-api/files/bootstrap/bases/kubeadmconfigs.bootstrap.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api/files/bootstrap/bases/kubeadmconfigs.bootstrap.cluster.x-k8s.io.yaml
@@ -22,7 +22,6 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Cg==
         service:
           name: capi-kubeadm-bootstrap-webhook-service
           namespace: '{{ .Release.Namespace }}'

--- a/helm/cluster-api/files/bootstrap/bases/kubeadmconfigtemplates.bootstrap.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api/files/bootstrap/bases/kubeadmconfigtemplates.bootstrap.cluster.x-k8s.io.yaml
@@ -22,7 +22,6 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Cg==
         service:
           name: capi-kubeadm-bootstrap-webhook-service
           namespace: '{{ .Release.Namespace }}'

--- a/helm/cluster-api/files/controlplane/bases/kubeadmcontrolplanes.controlplane.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api/files/controlplane/bases/kubeadmcontrolplanes.controlplane.cluster.x-k8s.io.yaml
@@ -22,7 +22,6 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Cg==
         service:
           name: capi-kubeadm-control-plane-webhook-service
           namespace: '{{ .Release.Namespace }}'

--- a/helm/cluster-api/files/controlplane/bases/kubeadmcontrolplanetemplates.controlplane.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api/files/controlplane/bases/kubeadmcontrolplanetemplates.controlplane.cluster.x-k8s.io.yaml
@@ -22,7 +22,6 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Cg==
         service:
           name: capi-kubeadm-control-plane-webhook-service
           namespace: '{{ .Release.Namespace }}'

--- a/helm/cluster-api/files/core/bases/clusterclasses.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api/files/core/bases/clusterclasses.cluster.x-k8s.io.yaml
@@ -21,7 +21,6 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Cg==
         service:
           name: capi-webhook-service
           namespace: '{{ .Release.Namespace }}'

--- a/helm/cluster-api/files/core/bases/clusterresourcesetbindings.addons.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api/files/core/bases/clusterresourcesetbindings.addons.cluster.x-k8s.io.yaml
@@ -21,7 +21,6 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Cg==
         service:
           name: capi-webhook-service
           namespace: '{{ .Release.Namespace }}'

--- a/helm/cluster-api/files/core/bases/clusterresourcesets.addons.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api/files/core/bases/clusterresourcesets.addons.cluster.x-k8s.io.yaml
@@ -21,7 +21,6 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Cg==
         service:
           name: capi-webhook-service
           namespace: '{{ .Release.Namespace }}'

--- a/helm/cluster-api/files/core/bases/clusters.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api/files/core/bases/clusters.cluster.x-k8s.io.yaml
@@ -21,7 +21,6 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Cg==
         service:
           name: capi-webhook-service
           namespace: '{{ .Release.Namespace }}'

--- a/helm/cluster-api/files/core/bases/machinedeployments.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api/files/core/bases/machinedeployments.cluster.x-k8s.io.yaml
@@ -21,7 +21,6 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Cg==
         service:
           name: capi-webhook-service
           namespace: '{{ .Release.Namespace }}'

--- a/helm/cluster-api/files/core/bases/machinehealthchecks.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api/files/core/bases/machinehealthchecks.cluster.x-k8s.io.yaml
@@ -21,7 +21,6 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Cg==
         service:
           name: capi-webhook-service
           namespace: '{{ .Release.Namespace }}'

--- a/helm/cluster-api/files/core/bases/machinepools.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api/files/core/bases/machinepools.cluster.x-k8s.io.yaml
@@ -21,7 +21,6 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Cg==
         service:
           name: capi-webhook-service
           namespace: '{{ .Release.Namespace }}'

--- a/helm/cluster-api/files/core/bases/machines.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api/files/core/bases/machines.cluster.x-k8s.io.yaml
@@ -21,7 +21,6 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Cg==
         service:
           name: capi-webhook-service
           namespace: '{{ .Release.Namespace }}'

--- a/helm/cluster-api/files/core/bases/machinesets.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api/files/core/bases/machinesets.cluster.x-k8s.io.yaml
@@ -21,7 +21,6 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Cg==
         service:
           name: capi-webhook-service
           namespace: '{{ .Release.Namespace }}'


### PR DESCRIPTION
Otherwise the CRDs can't be applied i.e. the app won't install.

This PR drops the field from our patches and commits these changes after `make generate`.