### PR TITLE
Chart: Use CAPI v1.9.10-gs-424bc0150.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Chart: Use CAPI v1.9.10-gs-424bc0150. ([#293](https://github.com/giantswarm/cluster-api-app/pull/293))
+
 ## [4.0.0] - 2025-08-13
 
 ### Changed

--- a/helm/cluster-api/values.yaml
+++ b/helm/cluster-api/values.yaml
@@ -25,7 +25,7 @@ images:
     # -- Control plane image repository.
     name: giantswarm/kubeadm-control-plane-controller
   # -- Image tag (used for all images).
-  tag: v1.9.10-gs-4a4b01921
+  tag: v1.9.10-gs-424bc0150
 
 # -- Webhook watch filter.
 watchFilter: capi


### PR DESCRIPTION
This image is basically the same as the old one, I only improved the CI a little, especially for pushing to China, and therefore want this app to use the image produced by the latest commit on the `release-1.9` branch, so nobody is getting confused by mismatches.